### PR TITLE
Chore: Fastapi 사양 낮추고 재배포

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # SKN14-Final-1Team-AI
 Repository for SKN14-Final-1Team-AI
+
+t3.large로 변경 후 재배포
+- 스토리지 : 40gb
+- 처리량 : 125
+- IOPS : 3,000


### PR DESCRIPTION
t3.large로 변경 후 재배포
- 스토리지 : 40gb
- 처리량 : 125
- IOPS : 3,000